### PR TITLE
[FD] Improved fix for "There is no started application" errors during…

### DIFF
--- a/app/uk/gov/hmrc/agentsubscription/GuiceModule.scala
+++ b/app/uk/gov/hmrc/agentsubscription/GuiceModule.scala
@@ -21,12 +21,22 @@ import javax.inject.Provider
 
 import com.google.inject.AbstractModule
 import com.google.inject.name.Names.named
+import play.api.Mode.Mode
+import play.api.{Configuration, Environment}
+import uk.gov.hmrc.agentsubscription.connectors.{AuthConnector, DesBusinessPartnerRecordApiConnector}
 import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.play.http.HttpGet
 
-class GuiceModule extends AbstractModule with ServicesConfig {
+class GuiceModule(environment: Environment, configuration: Configuration) extends AbstractModule with ServicesConfig {
+
+  override protected lazy val mode: Mode = environment.mode
+  override protected lazy val runModeConfiguration: Configuration = configuration
+
   override def configure(): Unit = {
     bind(classOf[HttpGet]).toInstance(WSHttp)
+    bind(classOf[HttpGet]).toInstance(WSHttp)
+    bind(classOf[DesBusinessPartnerRecordApiConnector])
+    bind(classOf[AuthConnector])
     bindBaseUrl("des")
     bindBaseUrl("auth")
     bindConfigProperty("des.authorization-token")

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -16,7 +16,7 @@ private object AppDependencies {
   private val playHealthVersion = "2.0.0"
   private val logbackJsonLoggerVersion = "3.1.0"
   private val playUrlBindersVersion = "2.0.0"
-  private val playConfigVersion = "3.0.0"
+  private val playConfigVersion = "3.1.0"
   private val domainVersion = "4.0.0"
   private val hmrcTestVersion = "2.2.0"
   private val scalaTestVersion = "2.2.6"


### PR DESCRIPTION
… Guice startup when running from binary

This adds the explicit bindings for DesBusinessPartnerRecordApiConnector and AuthConnector back but avoids the startup errors by using the Configuration instance during Guice initialisation, instead of letting ServiceConfig use the current Play app. An instance of Configuration is available to Guice modules, but not a current Play app.