### PR TITLE
[FD][APB-747] Use agency postcode instead of business postcode in HMRC-AS-AGENT enrolment

### DIFF
--- a/app/uk/gov/hmrc/agentsubscription/service/SubscriptionService.scala
+++ b/app/uk/gov/hmrc/agentsubscription/service/SubscriptionService.scala
@@ -93,12 +93,12 @@ class SubscriptionService @Inject() (
     )
 
   private def createKnownFacts(arn: Arn, subscriptionRequest: SubscriptionRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext) =
-    governmentGatewayAdminConnector.createKnownFacts(arn.arn, subscriptionRequest.knownFacts.postcode) recover {
+    governmentGatewayAdminConnector.createKnownFacts(arn.arn, subscriptionRequest.agency.address.postcode) recover {
       case e => throw new IllegalStateException(s"Failed to create known facts in GG for utr: ${subscriptionRequest.utr} and arn: ${arn.arn}", e)
     }
 
   private def enrol(arn: Arn, subscriptionRequest: SubscriptionRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext) =
-    governmentGatewayConnector.enrol(subscriptionRequest.agency.name, arn.arn, subscriptionRequest.knownFacts.postcode) recover {
+    governmentGatewayConnector.enrol(subscriptionRequest.agency.name, arn.arn, subscriptionRequest.agency.address.postcode) recover {
       case e => throw new IllegalStateException(s"Failed to create enrolment in GG for utr: ${subscriptionRequest.utr} and arn: ${arn.arn}", e)
     }
 

--- a/test/uk/gov/hmrc/agentsubscription/service/SubscriptionServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentsubscription/service/SubscriptionServiceSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.agentsubscription.service
 
 import org.mockito.ArgumentMatchers.{any, anyString, eq => eqs}
-import org.mockito.Mockito.{never, verify, when}
+import org.mockito.Mockito.{verify, when}
 import org.scalatest.concurrent.Eventually
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.FakeRequest
@@ -109,10 +109,7 @@ class SubscriptionServiceSpec extends UnitSpec with ResettingMockitoSugar with E
       await(service.subscribeAgentToMtd(subscriptionRequest))
 
       verify(ggAdminConnector).createKnownFacts(eqs(arn), eqs(agencyPostcode))(eqs(hc), any[ExecutionContext])
-      verify(ggAdminConnector, never()).createKnownFacts(eqs(arn), eqs(businessPostcode))(eqs(hc), any[ExecutionContext])
-
       verify(ggConnector).enrol(anyString, eqs(arn), eqs(agencyPostcode))(eqs(hc), any[ExecutionContext])
-      verify(ggConnector, never()).enrol(anyString, eqs(arn), eqs(businessPostcode))(eqs(hc), any[ExecutionContext])
     }
   }
 

--- a/test/uk/gov/hmrc/agentsubscription/service/SubscriptionServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentsubscription/service/SubscriptionServiceSpec.scala
@@ -17,53 +17,45 @@
 package uk.gov.hmrc.agentsubscription.service
 
 import org.mockito.ArgumentMatchers.{any, anyString, eq => eqs}
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito.{never, verify, when}
 import org.scalatest.concurrent.Eventually
-import org.scalatest.mock.MockitoSugar
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.FakeRequest
 import uk.gov.hmrc.agentsubscription.audit.AgentSubscriptionEvent.AgentSubscription
 import uk.gov.hmrc.agentsubscription.audit.AuditService
 import uk.gov.hmrc.agentsubscription.connectors.{Address => _, KnownFacts => _, _}
 import uk.gov.hmrc.agentsubscription.model._
+import uk.gov.hmrc.agentsubscription.support.ResettingMockitoSugar
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class SubscriptionServiceSpec extends UnitSpec with MockitoSugar with Eventually {
+class SubscriptionServiceSpec extends UnitSpec with ResettingMockitoSugar with Eventually {
 
-  implicit val hc = HeaderCarrier()
-  implicit val fakeRequest = FakeRequest("POST", "/agent-subscription/subscription")
+  private val desConnector = resettingMock[DesConnector]
+  private val ggAdminConnector = resettingMock[GovernmentGatewayAdminConnector]
+  private val ggConnector = resettingMock[GovernmentGatewayConnector]
+  private val auditService = resettingMock[AuditService]
+
+  private val service = new SubscriptionService(desConnector, ggAdminConnector, ggConnector, auditService)
+
+  private implicit val hc = HeaderCarrier()
+  private implicit val fakeRequest = FakeRequest("POST", "/agent-subscription/subscription")
 
   "subscribeAgentToMtd" should {
     "audit appropriate values" in {
-      val utr = "4000000009"
+      val businessUtr = "4000000009"
+      val businessPostcode = "AA1 1AA"
 
-      val desConnector = mock[DesConnector]
-      val ggAdminConnector = mock[GovernmentGatewayAdminConnector]
-      val ggConnector = mock[GovernmentGatewayConnector]
-      val auditService = mock[AuditService]
+      val arn = "ARN0001"
 
-      when(desConnector.getRegistration(eqs(utr))(eqs(hc), any[ExecutionContext]))
-        .thenReturn(Future successful Some(DesRegistrationResponse(
-          postalCode = Some("AA1 1AA"), isAnASAgent = false, organisationName = Some("Test Business"), None)))
-
-      when(desConnector.subscribeToAgentServices(anyString, any[DesSubscriptionRequest])(eqs(hc), any[ExecutionContext]))
-        .thenReturn(Future successful Arn("ARN0001"))
-
-      when(ggAdminConnector.createKnownFacts(eqs("ARN0001"), anyString)(eqs(hc), any[ExecutionContext]))
-        .thenReturn(Future successful new Integer(200))
-
-      when(ggConnector.enrol(anyString, anyString, anyString)(eqs(hc), any[ExecutionContext]))
-        .thenReturn(Future successful new Integer(200))
-
-      val service = new SubscriptionService(desConnector, ggAdminConnector, ggConnector, auditService)
+      subscriptionWillBeCreated(businessUtr, businessPostcode, arn)
 
       val subscriptionRequest = SubscriptionRequest(
-        utr,
-        KnownFacts("AA1 1AA"),
+        businessUtr,
+        KnownFacts(businessPostcode),
         Agency(
           "Test Agency",
           Address("1 Test Street", Some("address line 2"), Some("address line 3"), Some("address line 4"), postcode = "BB1 1BB", countryCode = "GB"),
@@ -84,10 +76,10 @@ class SubscriptionServiceSpec extends UnitSpec with MockitoSugar with Eventually
           |     "postcode": "BB1 1BB",
           |     "countryCode": "GB"
           |  },
-          |  "agentRegistrationNumber": "ARN0001",
+          |  "agentRegistrationNumber": "$arn",
           |  "agencyEmail": "testagency@example.com",
           |  "agencyTelephoneNumber": "01234 567890",
-          |  "utr": "$utr"
+          |  "utr": "$businessUtr"
           |}
           |""".stripMargin).asInstanceOf[JsObject]
       eventually {
@@ -95,5 +87,47 @@ class SubscriptionServiceSpec extends UnitSpec with MockitoSugar with Eventually
           .auditEvent(AgentSubscription, "Agent services subscription", expectedExtraDetail)(hc, fakeRequest)
       }
     }
+
+    "add the agency postcode, not the business postcode, to the HMRC-AS-AGENT enrolment known facts" in {
+      val utr = "4000000009"
+      val arn = "ARN0001"
+
+      val businessPostcode = "BU1 1BB"
+      val agencyPostcode = "AG1 1CY"
+
+      subscriptionWillBeCreated(utr, businessPostcode, arn)
+
+      val subscriptionRequest = SubscriptionRequest(
+        utr,
+        KnownFacts(businessPostcode),
+        Agency(
+          "Test Agency",
+          Address("1 Test Street", Some("address line 2"), Some("address line 3"), Some("address line 4"), postcode = agencyPostcode, countryCode = "GB"),
+          "01234 567890",
+          "testagency@example.com"))
+
+      await(service.subscribeAgentToMtd(subscriptionRequest))
+
+      verify(ggAdminConnector).createKnownFacts(eqs(arn), eqs(agencyPostcode))(eqs(hc), any[ExecutionContext])
+      verify(ggAdminConnector, never()).createKnownFacts(eqs(arn), eqs(businessPostcode))(eqs(hc), any[ExecutionContext])
+
+      verify(ggConnector).enrol(anyString, eqs(arn), eqs(agencyPostcode))(eqs(hc), any[ExecutionContext])
+      verify(ggConnector, never()).enrol(anyString, eqs(arn), eqs(businessPostcode))(eqs(hc), any[ExecutionContext])
+    }
+  }
+
+  private def subscriptionWillBeCreated(businessUtr: String, businessPostcode: String, arn: String) = {
+    when(desConnector.getRegistration(eqs(businessUtr))(eqs(hc), any[ExecutionContext]))
+      .thenReturn(Future successful Some(DesRegistrationResponse(
+        postalCode = Some(businessPostcode), isAnASAgent = false, organisationName = Some("Test Business"), None)))
+
+    when(desConnector.subscribeToAgentServices(anyString, any[DesSubscriptionRequest])(eqs(hc), any[ExecutionContext]))
+      .thenReturn(Future successful Arn(arn))
+
+    when(ggAdminConnector.createKnownFacts(eqs(arn), anyString)(eqs(hc), any[ExecutionContext]))
+      .thenReturn(Future successful new Integer(200))
+
+    when(ggConnector.enrol(anyString, anyString, anyString)(eqs(hc), any[ExecutionContext]))
+      .thenReturn(Future successful new Integer(200))
   }
 }

--- a/test/uk/gov/hmrc/agentsubscription/support/ResettingMockitoSugar.scala
+++ b/test/uk/gov/hmrc/agentsubscription/support/ResettingMockitoSugar.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentsubscription.support
+
+import org.mockito.Mockito
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{BeforeAndAfterEach, Suite}
+
+import scala.reflect.Manifest
+
+trait ResettingMockitoSugar extends MockitoSugar with BeforeAndAfterEach {
+  this: Suite =>
+
+  var mocksToReset = Seq.empty[Any]
+
+  def resettingMock[T <: AnyRef](implicit manifest: Manifest[T]): T = {
+    val m = mock[T](manifest)
+    mocksToReset = mocksToReset :+ m
+    m
+  }
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    Mockito.reset(mocksToReset: _*)
+  }
+}


### PR DESCRIPTION
So that HMRC-AS-AGENT contains the same data as the Agent Services Subscription in ETMP.