### PR TITLE
[APB-1190][JR] Temporary test-only endpoint for diagnosing QA connection to DES API.

### DIFF
--- a/app/uk/gov/hmrc/agentsubscription/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/agentsubscription/connectors/DesConnector.scala
@@ -61,6 +61,15 @@ object DesRegistrationRequest {
   implicit val formats: Format[DesRegistrationRequest] = Json.format[DesRegistrationRequest]
 }
 
+case class DesAgentRecordDetails(agencyDetails: Option[DesAgencyDetails])
+case class DesAgencyDetails(agencyName: String)
+
+object DesAgentRecordDetails {
+  implicit val agencyDetailsRead: Reads[DesAgencyDetails] = Json.reads[DesAgencyDetails]
+
+  implicit val agentRecordDetailsRead: Reads[DesAgentRecordDetails] = Json.reads[DesAgentRecordDetails]
+}
+
 @Singleton
 class DesConnector @Inject() (@Named("des.environment") environment: String,
                               @Named("des.authorization-token") authorizationToken: String,
@@ -113,7 +122,7 @@ class DesConnector @Inject() (@Named("des.environment") environment: String,
     val url = new URL(baseUrl, s"/registration/personal-details/arn/$encodedArn")
 
     (for {
-      agencyRecordDetails <- getWithDesHeaders[AgentRecordDetails]("GetAgentRecord", url)
+      agencyRecordDetails <- getWithDesHeaders[DesAgentRecordDetails]("GetAgentRecord", url)
     } yield agencyRecordDetails.agencyDetails.map(_.agencyName)
       ).recover {
       case _ => None
@@ -127,13 +136,4 @@ class DesConnector @Inject() (@Named("des.environment") environment: String,
 
     httpGet.GET[A](url.toString)(implicitly[HttpReads[A]], desHeaderCarrier, ec)
   }
-}
-
-case class AgentRecordDetails(agencyDetails: Option[AgencyDetails])
-case class AgencyDetails(agencyName: String)
-
-object AgentRecordDetails {
-  implicit val agencyDetailsRead: Reads[AgencyDetails] = Json.reads[AgencyDetails]
-
-  implicit val agentRecordDetailsRead: Reads[AgentRecordDetails] = Json.reads[AgentRecordDetails]
 }

--- a/app/uk/gov/hmrc/agentsubscription/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/agentsubscription/connectors/DesConnector.scala
@@ -21,11 +21,12 @@ import javax.inject.{Inject, Named, Singleton}
 
 import play.api.http.Status
 import play.api.libs.json._
+import play.utils.UriEncoding
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, Utr}
 import uk.gov.hmrc.play.encoding.UriPathEncoding.encodePathSegment
 
 import scala.concurrent.{ExecutionContext, Future}
-import uk.gov.hmrc.http.{ BadRequestException, HeaderCarrier, HttpPost, HttpReads }
+import uk.gov.hmrc.http._
 import uk.gov.hmrc.http.logging.Authorization
 
 case class Address(addressLine1: String,
@@ -64,6 +65,7 @@ object DesRegistrationRequest {
 class DesConnector @Inject() (@Named("des.environment") environment: String,
                               @Named("des.authorization-token") authorizationToken: String,
                               @Named("des-baseUrl") baseUrl: URL,
+                              httpGet: HttpGet,
                               httpPost: HttpPost) extends Status {
 
   def subscribeToAgentServices(utr: Utr, request: DesSubscriptionRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Arn] = {
@@ -104,4 +106,34 @@ class DesConnector @Inject() (@Named("des.environment") environment: String,
       authorization = Some(Authorization(s"Bearer $authorizationToken")),
       extraHeaders = hc.extraHeaders :+ "Environment" -> environment)
   }
+
+  def getAgencyName(arn: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[String]] = {
+
+    val encodedArn = UriEncoding.encodePathSegment(arn, "UTF-8")
+    val url = new URL(baseUrl, s"/registration/personal-details/arn/$encodedArn")
+
+    (for {
+      agencyRecordDetails <- getWithDesHeaders[AgentRecordDetails]("GetAgentRecord", url)
+    } yield agencyRecordDetails.agencyDetails.map(_.agencyName)
+      ).recover {
+      case _ => None
+    }
+  }
+
+  private def getWithDesHeaders[A: HttpReads](apiName: String, url: URL)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[A] = {
+    val desHeaderCarrier = hc.copy(
+      authorization = Some(Authorization(s"Bearer $authorizationToken")),
+      extraHeaders = hc.extraHeaders :+ "Environment" -> environment)
+
+    httpGet.GET[A](url.toString)(implicitly[HttpReads[A]], desHeaderCarrier, ec)
+  }
+}
+
+case class AgentRecordDetails(agencyDetails: Option[AgencyDetails])
+case class AgencyDetails(agencyName: String)
+
+object AgentRecordDetails {
+  implicit val agencyDetailsRead: Reads[AgencyDetails] = Json.reads[AgencyDetails]
+
+  implicit val agentRecordDetailsRead: Reads[AgentRecordDetails] = Json.reads[AgentRecordDetails]
 }

--- a/app/uk/gov/hmrc/agentsubscription/controllers/RegistrationController.scala
+++ b/app/uk/gov/hmrc/agentsubscription/controllers/RegistrationController.scala
@@ -23,9 +23,10 @@ import play.api.libs.json.Json.toJson
 import play.api.mvc.{Action, AnyContent, Result}
 import uk.gov.hmrc.agentsubscription.auth.{AuthActions, RequestWithAuthority}
 import uk.gov.hmrc.agentsubscription.connectors.AuthConnector
-import uk.gov.hmrc.agentsubscription.model.{postcodeWithoutSpacesRegex}
-import uk.gov.hmrc.agentmtdidentifiers.model.{Utr}
+import uk.gov.hmrc.agentsubscription.model.postcodeWithoutSpacesRegex
+import uk.gov.hmrc.agentmtdidentifiers.model.Utr
 import uk.gov.hmrc.agentsubscription.service.RegistrationService
+import uk.gov.hmrc.play.HeaderCarrierConverter
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
@@ -55,5 +56,14 @@ class RegistrationController @Inject()(service: RegistrationService, override va
 
   private def validPostcode(postcode: String): Boolean = {
     postcode.replaceAll("\\s", "").matches(postcodeWithoutSpacesRegex)
+  }
+
+  def getAgencyName(arn: String): Action[AnyContent] = Action.async { request =>
+    implicit val hc = HeaderCarrierConverter.fromHeadersAndSession(request.headers, None)
+
+    service.getAgencyName(arn).map {
+      case Some(name) => Ok(name)
+      case None => Ok("No name")
+    }
   }
 }

--- a/app/uk/gov/hmrc/agentsubscription/controllers/RegistrationController.scala
+++ b/app/uk/gov/hmrc/agentsubscription/controllers/RegistrationController.scala
@@ -58,12 +58,12 @@ class RegistrationController @Inject()(service: RegistrationService, override va
     postcode.replaceAll("\\s", "").matches(postcodeWithoutSpacesRegex)
   }
 
-  def getAgencyName(arn: String): Action[AnyContent] = Action.async { request =>
+  def getAgencyNameTestOnly(arn: String): Action[AnyContent] = Action.async { request =>
     implicit val hc = HeaderCarrierConverter.fromHeadersAndSession(request.headers, None)
 
     service.getAgencyName(arn).map {
-      case Some(name) => Ok(name)
-      case None => Ok("No name")
+      case Some(name) => Ok(Json.obj("name" -> name))
+      case None => NoContent
     }
   }
 }

--- a/app/uk/gov/hmrc/agentsubscription/service/RegistrationService.scala
+++ b/app/uk/gov/hmrc/agentsubscription/service/RegistrationService.scala
@@ -110,4 +110,6 @@ class RegistrationService @Inject() (desConnector: DesConnector, auditService: A
 
   private def toJsObject(detail: CheckAgencyStatusAuditDetail): JsObject = Json.toJson(detail).as[JsObject]
 
+  def getAgencyName(arn: String)(implicit hc: HeaderCarrier): Future[Option[String]] = desConnector.getAgencyName(arn)
+
 }

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -13,4 +13,4 @@
 ->         /                          prod.Routes
 
 
-GET     /agent-subscription/test-only/getAgencyName/:arn  @uk.gov.hmrc.agentsubscription.controllers.RegistrationController.getAgencyName(arn: String)
+GET     /agent-subscription/test-only/agency-name/:arn  @uk.gov.hmrc.agentsubscription.controllers.RegistrationController.getAgencyNameTestOnly(arn: String)

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -11,3 +11,6 @@
 
 # Add all the application routes to the prod.routes file
 ->         /                          prod.Routes
+
+
+GET     /agent-subscription/test-only/getAgencyName/:arn  @uk.gov.hmrc.agentsubscription.controllers.RegistrationController.getAgencyName(arn: String)


### PR DESCRIPTION
This is for diagnosing a DES call in QA only - it's not intended to be released beyond QA and is intended to be reverted after a test. 

The agent-services-account-frontend is failing to call a DES API in the QA environment. We have a theory that this is because DES can only be called from the protected zone, not the public zone.

To test that, instead of calling the DES API from the agent-services-account-frontend directly, that service will call a test-only endpoint in the agent-subscription backend which then calls the DES API. If that works in QA it confirms that we need a new agent-services-account backend in order to make the DES API call because it can't be done in the frontend. If it doesn't work, then there's some other problem.