### PR TITLE
[APB-5180][BS] SJR now saves with new authProviderId rather than CONFICT

### DIFF
--- a/app/uk/gov/hmrc/agentsubscription/auth/AuthActions.scala
+++ b/app/uk/gov/hmrc/agentsubscription/auth/AuthActions.scala
@@ -22,7 +22,7 @@ import play.api.libs.json.{ JsValue, Json, OFormat, Writes }
 import play.api.mvc.Results.{ Forbidden, Unauthorized }
 import play.api.mvc.{ AnyContent, Result, _ }
 import uk.gov.hmrc.agentsubscription.auth.AuthActions._
-import uk.gov.hmrc.agentsubscription.utils.toFuture
+import uk.gov.hmrc.agentsubscription.utils.valueOps
 import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{ affinityGroup, allEnrolments, credentials, groupIdentifier }
@@ -45,9 +45,9 @@ class AuthActions @Inject() (cc: ControllerComponents, val authConnector: AuthCo
             action(request)(AuthIds(providerId, groupId))
           } else {
             NotAnAgent
-          }
+          }.toFuture
 
-        case _ => GenericUnauthorized
+        case _ => GenericUnauthorized.toFuture
 
       } recover {
         handleFailure()
@@ -60,8 +60,8 @@ class AuthActions @Inject() (cc: ControllerComponents, val authConnector: AuthCo
         if (isAgent(affinityG))
           action(request)
         else
-          NotAnAgent
-      case _ => GenericUnauthorized
+          NotAnAgent.toFuture
+      case _ => GenericUnauthorized.toFuture
     } recover {
       handleFailure()
     }
@@ -72,12 +72,12 @@ class AuthActions @Inject() (cc: ControllerComponents, val authConnector: AuthCo
       .retrieve(allEnrolments and affinityGroup and credentials and groupIdentifier) {
         case enrolments ~ Some(affinityG) ~ Some(Credentials(providerId, _)) ~ Some(groupId) =>
           if (!isAgent(affinityG))
-            NotAnAgent
+            NotAnAgent.toFuture
           else if (enrolments.enrolments.nonEmpty)
-            AgentCannotSubscribe
+            AgentCannotSubscribe.toFuture
           else
             action(request)(AuthIds(providerId, groupId))
-        case _ => GenericUnauthorized
+        case _ => GenericUnauthorized.toFuture
       } recover {
         handleFailure()
       }
@@ -91,9 +91,9 @@ class AuthActions @Inject() (cc: ControllerComponents, val authConnector: AuthCo
             action(request)(Provider(providerId, providerType))
           } else {
             NotAnAgent
-          }
+          }.toFuture
 
-        case _ => GenericUnauthorized
+        case _ => GenericUnauthorized.toFuture
 
       } recover {
         handleFailure()

--- a/app/uk/gov/hmrc/agentsubscription/controllers/RegistrationController.scala
+++ b/app/uk/gov/hmrc/agentsubscription/controllers/RegistrationController.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.agentsubscription.auth.AuthActions
 import uk.gov.hmrc.agentsubscription.connectors.{ InvalidBusinessAddressException, InvalidIsAnASAgentException }
 import uk.gov.hmrc.agentsubscription.model.postcodeWithoutSpacesRegex
 import uk.gov.hmrc.agentsubscription.service.RegistrationService
-import uk.gov.hmrc.agentsubscription.utils.toFuture
+import uk.gov.hmrc.agentsubscription.utils.valueOps
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import scala.concurrent.ExecutionContext
@@ -58,7 +58,7 @@ class RegistrationController @Inject() (service: RegistrationService, authAction
   }
 
   private def badRequest(code: String) =
-    toFuture(BadRequest(Json.obj("code" -> code)))
+    BadRequest(Json.obj("code" -> code)).toFuture
 
   private def validPostcode(postcode: String): Boolean = {
     postcode.replaceAll("\\s", "").matches(postcodeWithoutSpacesRegex)

--- a/app/uk/gov/hmrc/agentsubscription/repository/SubscriptionJourneyRepository.scala
+++ b/app/uk/gov/hmrc/agentsubscription/repository/SubscriptionJourneyRepository.scala
@@ -51,6 +51,14 @@ class SubscriptionJourneyRepository @Inject() (
       upsert = true).checkResult
   }
 
+  @throws(classOf[DatabaseException])
+  def updateOnUtr(utr: Utr, record: SubscriptionJourneyRecord)(implicit ec: ExecutionContext): Future[Unit] = {
+    collection.update(ordered = false).one(
+      Json.obj("businessDetails.utr" -> utr.value),
+      record,
+      upsert = false).checkResult
+  }
+
   private implicit class WriteResultChecker(future: Future[WriteResult]) {
     def checkResult(implicit ec: ExecutionContext): Future[Unit] = future.map { writeResult =>
       if (hasProblems(writeResult)) throw new RuntimeException(writeResult.toString)

--- a/app/uk/gov/hmrc/agentsubscription/utils/package.scala
+++ b/app/uk/gov/hmrc/agentsubscription/utils/package.scala
@@ -20,8 +20,6 @@ import scala.concurrent.Future
 
 package object utils {
 
-  //implicit def toFuture[Result](a: Result): Future[Result] = Future.successful(a)
-
   implicit class throwableOps(val t: Throwable) extends AnyVal {
     def toFailure[A]: Future[A] = Future.failed(t)
   }

--- a/app/uk/gov/hmrc/agentsubscription/utils/package.scala
+++ b/app/uk/gov/hmrc/agentsubscription/utils/package.scala
@@ -20,6 +20,12 @@ import scala.concurrent.Future
 
 package object utils {
 
-  implicit def toFuture[T](a: T): Future[T] = Future.successful(a)
+  //implicit def toFuture[Result](a: Result): Future[Result] = Future.successful(a)
 
+  implicit class throwableOps(val t: Throwable) extends AnyVal {
+    def toFailure[A]: Future[A] = Future.failed(t)
+  }
+  implicit class valueOps[A](val a: A) extends AnyVal {
+    def toFuture: Future[A] = Future.successful(a)
+  }
 }

--- a/it/uk/gov/hmrc/agentsubscription/repository/SubscriptionJourneyRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscription/repository/SubscriptionJourneyRepositoryISpec.scala
@@ -98,5 +98,16 @@ class SubscriptionJourneyRepositoryISpec extends UnitSpec with GuiceOneAppPerSui
 
       await(repo.findByAuthId(AuthProviderId("auth-id"))) shouldBe Some(updatedSubscriptionJourney)
     }
+
+    "update a SubscriptionJourney record identified by its UTR" in {
+      val updatedSubscriptionJourney = subscriptionJourneyRecord
+        .copy(authProviderId = AuthProviderId("new-auth-id"))
+
+      await(repo.insert(subscriptionJourneyRecord))
+      await(repo.updateOnUtr(subscriptionJourneyRecord.businessDetails.utr, updatedSubscriptionJourney))
+
+      await(repo.findByAuthId(AuthProviderId("new-auth-id"))) shouldBe Some(updatedSubscriptionJourney)
+    }
+
   }
 }


### PR DESCRIPTION
I sneaked in a little change to replace the implicit conversion with an implicit class (since it wasn't used much anyway, I just went ahead and removed it).